### PR TITLE
[Refactor]내 처방전 리턴값, oauth 리턴값, 유저 관련 추천 로직 수정

### DIFF
--- a/src/main/java/kr/KWGraduate/BookPharmacy/domain/book/repository/ClientRecommendRepository.java
+++ b/src/main/java/kr/KWGraduate/BookPharmacy/domain/book/repository/ClientRecommendRepository.java
@@ -9,9 +9,9 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface ClientRecommendRepository extends JpaRepository<ClientRecommend ,Long> {
-    @Query("select cr from ClientRecommend cr join fetch cr.book b where cr.client.id = :clientId and cr.rank >= 3")
+    @Query("select cr from ClientRecommend cr join fetch cr.book b where cr.client.id = :clientId and cr.rank >= 7")
     List<ClientRecommend> findByClientBasedRecommend(@Param("clientId") Long clientId);
 
-    @Query("select cr from ClientRecommend cr join fetch cr.book b where cr.client.id = :clientId and cr.rank < 3")
+    @Query("select cr from ClientRecommend cr join fetch cr.book b where cr.client.id = :clientId and cr.rank < 7")
     List<ClientRecommend> findByClientAiPrescription(@Param("clientId") Long clientId);
 }

--- a/src/main/java/kr/KWGraduate/BookPharmacy/domain/book/service/RecommendService.java
+++ b/src/main/java/kr/KWGraduate/BookPharmacy/domain/book/service/RecommendService.java
@@ -1,5 +1,6 @@
 package kr.KWGraduate.BookPharmacy.domain.book.service;
 
+import kr.KWGraduate.BookPharmacy.domain.book.domain.ClientRecommend;
 import kr.KWGraduate.BookPharmacy.domain.book.dto.response.BoardBasedRecommendDto;
 import kr.KWGraduate.BookPharmacy.domain.book.dto.response.BookBasedRecommendDto;
 import kr.KWGraduate.BookPharmacy.domain.book.dto.response.ClientBasedRecommendDto;
@@ -12,6 +13,8 @@ import kr.KWGraduate.BookPharmacy.global.security.common.dto.AuthenticationAdapt
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,7 +30,11 @@ public class RecommendService {
         String username = authentication.getUsername();
         Client client = clientRepository.findByLoginId(username).get();
 
-        return clientRecommendRepository.findByClientAiPrescription(client.getId()).stream()
+        List<ClientRecommend> clientRecommend = clientRecommendRepository.findByClientAiPrescription(client.getId());
+        Collections.shuffle(clientRecommend);
+        return clientRecommend.stream()
+                .limit(3)
+                .sorted(Comparator.comparingInt(ClientRecommend::getRank))
                 .map(ClientBasedRecommendDto::new)
                 .collect(Collectors.toList());
     }
@@ -35,7 +42,12 @@ public class RecommendService {
         String username = authentication.getUsername();
         Client client = clientRepository.findByLoginId(username).get();
 
-        return clientRecommendRepository.findByClientBasedRecommend(client.getId()).stream()
+        List<ClientRecommend> clientRecommend = clientRecommendRepository.findByClientBasedRecommend(client.getId());
+        Collections.shuffle(clientRecommend);
+
+        return clientRecommend.stream()
+                .limit(10)
+                .sorted(Comparator.comparingInt(ClientRecommend::getRank))
                 .map(ClientBasedRecommendDto::new)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/kr/KWGraduate/BookPharmacy/domain/client/dto/response/ClientMypageDto.java
+++ b/src/main/java/kr/KWGraduate/BookPharmacy/domain/client/dto/response/ClientMypageDto.java
@@ -23,7 +23,11 @@ public class ClientMypageDto {
 
     @Builder
     public ClientMypageDto(Client client) {
-        this.loginId = client.getLoginId();
+        if(client.getLoginId().startsWith("naver")){
+            this.loginId = client.getLoginId().substring(6,12);
+        }else{
+            this.loginId = client.getLoginId();
+        }
         this.name = client.getName();
         this.nickname = client.getNickname();
         this.email = client.getEmail();

--- a/src/main/java/kr/KWGraduate/BookPharmacy/domain/prescription/api/PrescriptionController.java
+++ b/src/main/java/kr/KWGraduate/BookPharmacy/domain/prescription/api/PrescriptionController.java
@@ -9,6 +9,7 @@ import kr.KWGraduate.BookPharmacy.domain.prescription.dto.response.PrescriptionM
 import kr.KWGraduate.BookPharmacy.domain.prescription.service.PrescriptionService;
 import kr.KWGraduate.BookPharmacy.global.security.common.dto.AuthenticationAdapter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
@@ -27,7 +28,7 @@ public class PrescriptionController {
 
     @GetMapping
     @Operation(summary = "게시물에 대한 처방전 조회", description = "무한 스크롤 사용으로 인해 page와 size입력")
-    public ResponseEntity<List<PrescriptionBoardPageDto>> getPrescription(
+    public ResponseEntity<Page<PrescriptionBoardPageDto>> getPrescription(
             @RequestParam("page") int page,
             @RequestParam("size") int size,
             @RequestParam("boardId") Long boardId
@@ -38,7 +39,7 @@ public class PrescriptionController {
 
     @GetMapping("/my")
     @Operation(summary = "나의 처방전 조회", description = "무한 스크롤 사용으로 인해 page와 size입력")
-    public ResponseEntity<List<PrescriptionMyPageDto>> getPrescription(
+    public ResponseEntity<Page<PrescriptionMyPageDto>> getPrescription(
             @RequestParam("page") int page,
             @RequestParam("size") int size,
             @AuthenticationPrincipal AuthenticationAdapter userDetails

--- a/src/main/java/kr/KWGraduate/BookPharmacy/domain/prescription/repository/PrescriptionRepository.java
+++ b/src/main/java/kr/KWGraduate/BookPharmacy/domain/prescription/repository/PrescriptionRepository.java
@@ -1,6 +1,7 @@
 package kr.KWGraduate.BookPharmacy.domain.prescription.repository;
 
 import kr.KWGraduate.BookPharmacy.domain.prescription.domain.Prescription;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,10 +13,10 @@ import java.util.List;
 
 public interface PrescriptionRepository extends JpaRepository<Prescription, Long> {
     @Query("select p from Prescription p join fetch p.board b where b.id = :id")
-    Slice<Prescription> findByBoardId(Pageable pageable, @Param("id") Long boardId);
+    Page<Prescription> findByBoardId(Pageable pageable, @Param("id") Long boardId);
 
     @Query("select p from Prescription p join fetch p.client c where c.loginId = :loginId")
-    Slice<Prescription> findByUsername(Pageable pageable, @Param("loginId") String username);
+    Page<Prescription> findByUsername(Pageable pageable, @Param("loginId") String username);
 
 
     @Query("select b.id, count(p) from Prescription p join p.board b where b.id in :boardIds group by b.id")

--- a/src/main/java/kr/KWGraduate/BookPharmacy/domain/prescription/service/PrescriptionService.java
+++ b/src/main/java/kr/KWGraduate/BookPharmacy/domain/prescription/service/PrescriptionService.java
@@ -1,5 +1,6 @@
 package kr.KWGraduate.BookPharmacy.domain.prescription.service;
 
+import kr.KWGraduate.BookPharmacy.domain.board.dto.response.BoardConcernPageDto;
 import kr.KWGraduate.BookPharmacy.domain.prescription.dto.request.PrescriptionCreateDto;
 import kr.KWGraduate.BookPharmacy.domain.prescription.dto.request.PrescriptionModifyDto;
 import kr.KWGraduate.BookPharmacy.domain.prescription.dto.response.PrescriptionBoardPageDto;
@@ -14,6 +15,7 @@ import kr.KWGraduate.BookPharmacy.domain.book.repository.BookRepository;
 import kr.KWGraduate.BookPharmacy.domain.client.repository.ClientRepository;
 import kr.KWGraduate.BookPharmacy.domain.prescription.repository.PrescriptionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,16 +31,14 @@ public class PrescriptionService {
     private final BoardRepository boardRepository;
     private final ClientRepository clientRepository;
     private final BookRepository bookRepository;
-    public List<PrescriptionBoardPageDto> getPrescriptions(Pageable pageable , Long boardId){
-        return prescriptionRepository.findByBoardId(pageable, boardId).stream()
-                .map(PrescriptionBoardPageDto::new)
-                .collect(Collectors.toList());
+    public Page<PrescriptionBoardPageDto> getPrescriptions(Pageable pageable , Long boardId){
+        return prescriptionRepository.findByBoardId(pageable, boardId)
+                .map(PrescriptionBoardPageDto::new);
     }
 
-    public List<PrescriptionMyPageDto> getPrescriptions(Pageable pageable , AuthenticationAdapter authentication){
-        return prescriptionRepository.findByUsername(pageable, authentication.getUsername()).stream()
-                .map(PrescriptionMyPageDto::new)
-                .collect(Collectors.toList());
+    public Page<PrescriptionMyPageDto> getPrescriptions(Pageable pageable , AuthenticationAdapter authentication){
+        return prescriptionRepository.findByUsername(pageable, authentication.getUsername())
+                .map(PrescriptionMyPageDto::new);
     }
 
     public PrescriptionBoardPageDto getPrescription(Long prescriptionId) {


### PR DESCRIPTION
# Overview
내 처방전 리턴값, oauth 리턴값, 유저 관련 추천 로직 수정

# 변경 유형
* [x] 기능 추가 
* [ ] 버그 수정
* [ ] 성능 개선
* [ ] TC 추가
* [x] 기타 설정(환경 설정, CI/CD, 문서...)

# 수정 내용
1. 클라이언트 추천 랜덤 13개 가져오기
2. 처방전 api 무한 스크롤을 위해 Page타입으로 변경
3. oauth아이디 호출 시 slicing해서 출력

# 레퍼런스